### PR TITLE
Add environment-aware Unity discovery for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Cake is a generalized distributed build system created with the Unity game engin
 
 SeudoBuild uses a JSON build configuration file that define project and target parameters.
 
+## Unity installation discovery
+
+Unity build steps attempt to locate the appropriate Unity editor automatically.
+On macOS the editor is discovered under `/Applications`, while on Windows and Linux the
+search starts from a set of common Unity Hub and standalone install locations.
+The lookup can be customized with the following environment variables:
+
+* `UNITY_WINDOWS_EDITOR_PATH` – full path to a specific `Unity.exe`.
+* `UNITY_WINDOWS_INSTALLATION_ROOT` – directory that contains Unity versions (for example `C\\Program Files\Unity\Hub\Editor`).
+* `UNITY_LINUX_EDITOR_PATH` – full path to the Unity binary on Linux.
+* `UNITY_LINUX_INSTALLATION_ROOT` – directory that contains Unity versions on Linux (for example `~/Unity/Hub/Editor`).
+
+When the root variables are provided, the build step expects each Unity version to reside in a
+subdirectory named after the version string (e.g. `2022.1.0f1`) with the editor binary located in
+`Editor/Unity[.exe]`.
+
+
 ## Modes
 
 ### Build

--- a/SeudoCI.Pipeline.Modules.UnityBuild/UnityInstallation.cs
+++ b/SeudoCI.Pipeline.Modules.UnityBuild/UnityInstallation.cs
@@ -1,44 +1,52 @@
-﻿namespace SeudoCI.Pipeline.Modules.UnityBuild;
+namespace SeudoCI.Pipeline.Modules.UnityBuild;
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Core;
 
 public class UnityInstallation
 {
+    private const string WindowsEditorPathEnv = "UNITY_WINDOWS_EDITOR_PATH";
+    private const string WindowsRootEnv = "UNITY_WINDOWS_INSTALLATION_ROOT";
+    private const string LinuxEditorPathEnv = "UNITY_LINUX_EDITOR_PATH";
+    private const string LinuxRootEnv = "UNITY_LINUX_INSTALLATION_ROOT";
+
     /// <summary>
     /// Version number of the installed executable that may be
     /// used by a Unity build step.
     /// </summary>
-    public VersionNumber Version { get; set; }
+    public VersionNumber? Version { get; set; }
 
     /// <summary>
     /// Full path to the Unity installation folder.
     /// </summary>
     /// <value>The folder.</value>
-    public string Folder { get; set; }
+    public string? Folder { get; set; }
 
     /// <summary>
     /// Full path to the Unity executable.
     /// </summary>
-    public string ExePath { get; set; }
+    public string? ExePath { get; set; }
 
     /// <summary>
-    /// Finds an Unity executable inside an installation folder with
+    /// Finds a Unity executable inside an installation folder with
     /// the folder name ending with the given version number.
     /// Example:  /Applications/Unity 5.3.4f2/Unity.app
     /// </summary>
-    public static UnityInstallation FindUnityInstallation(VersionNumber version, Platform platform)
+    public static UnityInstallation FindUnityInstallation(VersionNumber? version, Platform platform)
     {
         switch (platform)
         {
             case Platform.Mac:
                 // find the installation folder
                 string installationPath = "/Applications/";
-                string versionString = version != null ? version.ToString() : "";
+                string versionString = version != null ? version.ToString() : string.Empty;
                 bool foundInstallationFolder = false;
                 foreach (var dir in Directory.GetDirectories(installationPath))
                 {
                     string filename = Path.GetFileName(dir);
-                    if (filename.StartsWith("Unity") && filename.EndsWith(versionString))
+                    if (filename.StartsWith("Unity", StringComparison.OrdinalIgnoreCase) && filename.EndsWith(versionString, StringComparison.OrdinalIgnoreCase))
                     {
                         foundInstallationFolder = true;
                         installationPath += Path.GetFileName(dir);
@@ -56,7 +64,7 @@ public class UnityInstallation
                 foreach (var dir in Directory.GetDirectories(installationPath))
                 {
                     string filename = Path.GetFileName(dir);
-                    if (filename.StartsWith("Unity") && !filename.StartsWith("Unity Bug Reporter") && filename.EndsWith(".app"))
+                    if (filename.StartsWith("Unity", StringComparison.OrdinalIgnoreCase) && !filename.StartsWith("Unity Bug Reporter", StringComparison.OrdinalIgnoreCase) && filename.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
                     {
                         foundAppBundle = true;
                         appBundlePath += "/" + filename;
@@ -71,8 +79,323 @@ public class UnityInstallation
                 string exePath = $"{appBundlePath}/Contents/MacOS/Unity";
                 var installation = new UnityInstallation { Version = version, Folder = installationPath, ExePath = exePath };
                 return installation;
+            case Platform.Windows:
+                return FindDesktopInstallation(version, platform, WindowsEditorPathEnv, WindowsRootEnv, "Unity.exe", GetWindowsRoots());
+            case Platform.Linux:
+                return FindDesktopInstallation(version, platform, LinuxEditorPathEnv, LinuxRootEnv, "Unity", GetLinuxRoots());
             default:
                 throw new PlatformNotSupportedException($"{platform} platform is not supported for Unity builds");
         }
+    }
+
+    private static UnityInstallation FindDesktopInstallation(
+        VersionNumber? version,
+        Platform platform,
+        string directOverrideEnv,
+        string rootOverrideEnv,
+        string exeFileName,
+        IEnumerable<string> knownRoots)
+    {
+        var attemptedPaths = new List<string>();
+        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var directOverride = Environment.GetEnvironmentVariable(directOverrideEnv);
+        var directInstallation = TryResolveCandidate(directOverride, version, exeFileName, attemptedPaths, seenPaths);
+        if (directInstallation != null)
+        {
+            return directInstallation;
+        }
+
+        var overrideRoot = Environment.GetEnvironmentVariable(rootOverrideEnv);
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
+        {
+            var installation = TryResolveFromRoot(overrideRoot, version, exeFileName, attemptedPaths, seenPaths);
+            if (installation != null)
+            {
+                return installation;
+            }
+        }
+
+        var seenRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in knownRoots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+
+            var expandedRoot = ExpandPath(root);
+            if (!seenRoots.Add(expandedRoot))
+            {
+                continue;
+            }
+
+            var installation = TryResolveFromRoot(expandedRoot, version, exeFileName, attemptedPaths, seenPaths);
+            if (installation != null)
+            {
+                return installation;
+            }
+        }
+
+        var searched = attemptedPaths.Count == 0 ? "none" : string.Join(", ", attemptedPaths);
+        throw new Exception($"Could not find Unity installation for {platform}. Paths searched: {searched}");
+    }
+
+    private static UnityInstallation? TryResolveFromRoot(
+        string root,
+        VersionNumber? version,
+        string exeFileName,
+        ICollection<string> attemptedPaths,
+        ISet<string> seenPaths)
+    {
+        var installation = TryResolveCandidate(root, version, exeFileName, attemptedPaths, seenPaths);
+        if (installation != null)
+        {
+            return installation;
+        }
+
+        var expandedRoot = ExpandPath(root);
+        if (!Directory.Exists(expandedRoot))
+        {
+            return null;
+        }
+
+        var versionString = version?.ToString();
+        if (!string.IsNullOrEmpty(versionString))
+        {
+            foreach (var folderName in GetVersionCandidateFolders(versionString))
+            {
+                var candidatePath = Path.Combine(expandedRoot, folderName);
+                installation = TryResolveCandidate(candidatePath, version, exeFileName, attemptedPaths, seenPaths);
+                if (installation != null)
+                {
+                    return installation;
+                }
+            }
+        }
+
+        foreach (var directory in SafeEnumerateDirectories(expandedRoot))
+        {
+            installation = TryResolveCandidate(directory, version, exeFileName, attemptedPaths, seenPaths);
+            if (installation != null)
+            {
+                return installation;
+            }
+        }
+
+        return null;
+    }
+
+    private static UnityInstallation? TryResolveCandidate(
+        string? candidate,
+        VersionNumber? version,
+        string exeFileName,
+        ICollection<string> attemptedPaths,
+        ISet<string> seenPaths)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return null;
+        }
+
+        var expanded = ExpandPath(candidate);
+        if (string.IsNullOrWhiteSpace(expanded))
+        {
+            return null;
+        }
+
+        AddAttemptedPath(attemptedPaths, seenPaths, expanded);
+
+        if (File.Exists(expanded))
+        {
+            return CreateInstallation(expanded, version);
+        }
+
+        if (!Directory.Exists(expanded))
+        {
+            return null;
+        }
+
+        var directExe = Path.Combine(expanded, exeFileName);
+        AddAttemptedPath(attemptedPaths, seenPaths, directExe);
+        if (File.Exists(directExe))
+        {
+            return CreateInstallation(directExe, version);
+        }
+
+        var editorExe = Path.Combine(expanded, "Editor", exeFileName);
+        AddAttemptedPath(attemptedPaths, seenPaths, editorExe);
+        if (File.Exists(editorExe))
+        {
+            return CreateInstallation(editorExe, version);
+        }
+
+        return null;
+    }
+
+    private static void AddAttemptedPath(ICollection<string> attemptedPaths, ISet<string> seenPaths, string path)
+    {
+        if (seenPaths.Add(path))
+        {
+            attemptedPaths.Add(path);
+        }
+    }
+
+    private static UnityInstallation CreateInstallation(string exePath, VersionNumber? version)
+    {
+        var folder = Path.GetDirectoryName(exePath) ?? exePath;
+        return new UnityInstallation
+        {
+            Version = version,
+            Folder = folder,
+            ExePath = exePath
+        };
+    }
+
+    private static IEnumerable<string> SafeEnumerateDirectories(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            yield break;
+        }
+
+        string[] directories;
+
+        try
+        {
+            directories = Directory.GetDirectories(path);
+        }
+        catch (IOException)
+        {
+            yield break;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (var directory in directories)
+        {
+            yield return directory;
+        }
+    }
+
+    private static IEnumerable<string> GetVersionCandidateFolders(string versionString)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var candidate in new[]
+                 {
+                     versionString,
+                     $"Unity {versionString}",
+                     $"Unity_{versionString}",
+                     $"Unity-{versionString}",
+                     $"Unity{versionString}"
+                 })
+        {
+            if (seen.Add(candidate))
+            {
+                yield return candidate;
+            }
+        }
+    }
+
+    private static string ExpandPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        var expanded = Environment.ExpandEnvironmentVariables(path);
+        if (expanded.StartsWith("~", StringComparison.Ordinal))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrEmpty(home))
+            {
+                if (expanded.Length == 1)
+                {
+                    expanded = home;
+                }
+                else if (expanded.Length > 1 && (expanded[1] == '/' || expanded[1] == '\\'))
+                {
+                    var remainder = expanded.Substring(2);
+                    expanded = Path.Combine(home, remainder);
+                }
+            }
+        }
+
+        return expanded;
+    }
+
+    private static IEnumerable<string> GetWindowsRoots()
+    {
+        var roots = new List<string>
+        {
+            @"C:\\Program Files\\Unity",
+            @"C:\\Program Files\\Unity\\Hub\\Editor",
+            @"C:\\Program Files\\Unity Hub\\Editor",
+            @"C:\\Program Files (x86)\\Unity",
+            @"C:\\Program Files (x86)\\Unity\\Hub\\Editor",
+            @"C:\\Program Files (x86)\\Unity Hub\\Editor"
+        };
+
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (!string.IsNullOrWhiteSpace(programFiles))
+        {
+            roots.Add(Path.Combine(programFiles, "Unity"));
+            roots.Add(Path.Combine(programFiles, "Unity", "Hub", "Editor"));
+            roots.Add(Path.Combine(programFiles, "Unity Hub", "Editor"));
+        }
+
+        var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        if (!string.IsNullOrWhiteSpace(programFilesX86))
+        {
+            roots.Add(Path.Combine(programFilesX86, "Unity"));
+            roots.Add(Path.Combine(programFilesX86, "Unity", "Hub", "Editor"));
+            roots.Add(Path.Combine(programFilesX86, "Unity Hub", "Editor"));
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            roots.Add(Path.Combine(localAppData, "Programs", "Unity"));
+            roots.Add(Path.Combine(localAppData, "Unity", "Hub", "Editor"));
+            roots.Add(Path.Combine(localAppData, "UnityHub", "Editor"));
+        }
+
+        return roots;
+    }
+
+    private static IEnumerable<string> GetLinuxRoots()
+    {
+        var roots = new List<string>
+        {
+            "/opt/Unity",
+            "/opt/Unity/Hub/Editor",
+            "/opt/unity",
+            "/opt/unity/Hub/Editor",
+            "/opt/unityhub/Editor",
+            "/usr/share/unity3d",
+            "/usr/local/share/unity3d",
+            "~/Unity",
+            "~/Unity/Hub/Editor",
+            "~/UnityHub/Editor",
+            "~/.local/share/Unity",
+            "~/.local/share/UnityHub/Editor",
+            "~/.local/share/unity3d"
+        };
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            roots.Add(Path.Combine(home, "Unity"));
+            roots.Add(Path.Combine(home, "Unity", "Hub", "Editor"));
+            roots.Add(Path.Combine(home, "UnityHub", "Editor"));
+            roots.Add(Path.Combine(home, ".local", "share", "Unity"));
+            roots.Add(Path.Combine(home, ".local", "share", "UnityHub", "Editor"));
+            roots.Add(Path.Combine(home, ".local", "share", "unity3d"));
+        }
+
+        return roots;
     }
 }

--- a/SeudoCI.Pipeline.Tests/SeudoCI.Pipeline.Tests.csproj
+++ b/SeudoCI.Pipeline.Tests/SeudoCI.Pipeline.Tests.csproj
@@ -25,6 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.UnityBuild\SeudoCI.Pipeline.Modules.UnityBuild.csproj" />
       <ProjectReference Include="..\SeudoCI.Pipeline.Shared\SeudoCI.Pipeline.Shared.csproj" />
       <ProjectReference Include="..\SeudoCI.Pipeline\SeudoCI.Pipeline.csproj" />
     </ItemGroup>

--- a/SeudoCI.Pipeline.Tests/UnityInstallationPlatformTests.cs
+++ b/SeudoCI.Pipeline.Tests/UnityInstallationPlatformTests.cs
@@ -1,0 +1,96 @@
+namespace SeudoCI.Pipeline.Tests;
+
+using System;
+using System.IO;
+using Core;
+using SeudoCI.Pipeline.Modules.UnityBuild;
+using SeudoCI.Pipeline;
+
+[TestFixture]
+public class UnityInstallationPlatformTests
+{
+    [Test]
+    public void FindUnityInstallation_Windows_UsesEnvironmentRootOverride()
+    {
+        var version = new VersionNumber { Major = 2021, Minor = 3, Patch = 5, Build = "f1" };
+        var layout = CreateUnityLayout("windows-layout", "Unity.exe", version);
+
+        Environment.SetEnvironmentVariable("UNITY_WINDOWS_EDITOR_PATH", null);
+        Environment.SetEnvironmentVariable("UNITY_WINDOWS_INSTALLATION_ROOT", layout.Root);
+
+        try
+        {
+            var installation = UnityInstallation.FindUnityInstallation(version, Platform.Windows);
+
+            Assert.That(installation, Is.Not.Null);
+            Assert.That(installation.ExePath, Is.EqualTo(layout.ExePath));
+            Assert.That(installation.Folder, Is.EqualTo(Path.GetDirectoryName(layout.ExePath)));
+            Assert.That(installation.Version, Is.EqualTo(version));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("UNITY_WINDOWS_INSTALLATION_ROOT", null);
+            Environment.SetEnvironmentVariable("UNITY_WINDOWS_EDITOR_PATH", null);
+            CleanupLayout(layout.Root);
+        }
+    }
+
+    [Test]
+    public void FindUnityInstallation_Linux_UsesEnvironmentRootOverride()
+    {
+        var version = new VersionNumber { Major = 2022, Minor = 1, Patch = 0, Build = "f1" };
+        var layout = CreateUnityLayout("linux-layout", "Unity", version);
+
+        Environment.SetEnvironmentVariable("UNITY_LINUX_EDITOR_PATH", null);
+        Environment.SetEnvironmentVariable("UNITY_LINUX_INSTALLATION_ROOT", layout.Root);
+
+        try
+        {
+            var installation = UnityInstallation.FindUnityInstallation(version, Platform.Linux);
+
+            Assert.That(installation, Is.Not.Null);
+            Assert.That(installation.ExePath, Is.EqualTo(layout.ExePath));
+            Assert.That(installation.Folder, Is.EqualTo(Path.GetDirectoryName(layout.ExePath)));
+            Assert.That(installation.Version, Is.EqualTo(version));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("UNITY_LINUX_INSTALLATION_ROOT", null);
+            Environment.SetEnvironmentVariable("UNITY_LINUX_EDITOR_PATH", null);
+            CleanupLayout(layout.Root);
+        }
+    }
+
+    private static (string Root, string ExePath) CreateUnityLayout(string name, string exeFileName, VersionNumber version)
+    {
+        var baseDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, name);
+        CleanupLayout(baseDirectory);
+
+        var editorDirectory = Path.Combine(baseDirectory, version.ToString(), "Editor");
+        Directory.CreateDirectory(editorDirectory);
+
+        var exePath = Path.Combine(editorDirectory, exeFileName);
+        File.WriteAllText(exePath, string.Empty);
+
+        return (baseDirectory, exePath);
+    }
+
+    private static void CleanupLayout(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+        catch (IOException)
+        {
+            // ignore cleanup failures in test tear down
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // ignore cleanup failures in test tear down
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Windows and Linux search paths in `UnityInstallation`, including environment variable overrides
- add tests that validate Windows and Linux discovery via configurable roots
- document the environment variables that influence Unity editor discovery

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb13a61da8832e945f679e3e9009f4