### PR TITLE
Harden email notify step

### DIFF
--- a/SeudoCI.Pipeline.Modules.EmailNotify.Shared/EmailNotifyConfig.cs
+++ b/SeudoCI.Pipeline.Modules.EmailNotify.Shared/EmailNotifyConfig.cs
@@ -9,7 +9,7 @@ public class EmailNotifyConfig : NotifyStepConfig
     public override string Name { get; } = "Email Notification";
     public string FromAddress { get; set; } = string.Empty;
     public string ToAddress { get; set; } = string.Empty;
-    public string Host { get; set; } = "smtp.google.com";
+    public string Host { get; set; } = "smtp.gmail.com";
     public int Port { get; set; } = 587;
     public string SMTPUser { get; set; } = string.Empty;
     public string SMTPPassword { get; set; } = string.Empty;

--- a/SeudoCI.Pipeline.Modules.EmailNotify/EmailNotifyStep.cs
+++ b/SeudoCI.Pipeline.Modules.EmailNotify/EmailNotifyStep.cs
@@ -3,19 +3,25 @@
 namespace SeudoCI.Pipeline.Modules.EmailNotify;
 
 using MailKit.Net.Smtp;
+using MailKit.Security;
 using MimeKit;
 using Core;
 
 public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
 {
-    private EmailNotifyConfig _config;
-    private ILogger _logger;
+    private EmailNotifyConfig _config = null!;
+    private ILogger _logger = null!;
 
     public string? Type => "Email Notification";
 
     [UsedImplicitly]
     public void Initialize(EmailNotifyConfig config, ITargetWorkspace workspace, ILogger logger)
     {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        ValidateConfiguration(config);
+
         _config = config;
         _logger = logger;
     }
@@ -38,8 +44,8 @@ public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
     private void SendMessage(string fromAddress, string toAddress, string subject, string body)
     {
         var message = new MimeMessage();
-        message.From.Add(new MailboxAddress("SeudoCI", fromAddress));
-        message.To.Add(new MailboxAddress("recipient", toAddress));
+        message.From.Add(MailboxAddress.Parse(fromAddress));
+        message.To.Add(MailboxAddress.Parse(toAddress));
         message.Subject = subject;
         message.Body = new TextPart("plain")
         {
@@ -51,10 +57,7 @@ public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
         using (var client = new SmtpClient())
         {
             client.Timeout = 10000;
-            client.ServerCertificateValidationCallback = (s, c, h, e) => true;
-            client.Connect(_config.Host, _config.Port, false);
-            // Note: since we don't have an OAuth2 token, disable
-            // the XOAUTH2 authentication mechanism.
+            client.Connect(_config.Host, _config.Port, GetSecureSocketOptions(_config.Port));
             client.AuthenticationMechanisms.Remove("XOAUTH2");
             client.Authenticate(_config.SMTPUser, _config.SMTPPassword);
             client.Send(message);
@@ -62,5 +65,53 @@ public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
         }
 
         _logger.Write("Email notification sent", LogType.SmallBullet);
+    }
+
+    private static SecureSocketOptions GetSecureSocketOptions(int port)
+    {
+        return port == 465 ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTlsWhenAvailable;
+    }
+
+    private static void ValidateConfiguration(EmailNotifyConfig config)
+    {
+        if (string.IsNullOrWhiteSpace(config.FromAddress))
+        {
+            throw new ArgumentException("FromAddress cannot be empty", nameof(config.FromAddress));
+        }
+
+        if (!MailboxAddress.TryParse(config.FromAddress, out _))
+        {
+            throw new ArgumentException("FromAddress is not a valid email address", nameof(config.FromAddress));
+        }
+
+        if (string.IsNullOrWhiteSpace(config.ToAddress))
+        {
+            throw new ArgumentException("ToAddress cannot be empty", nameof(config.ToAddress));
+        }
+
+        if (!MailboxAddress.TryParse(config.ToAddress, out _))
+        {
+            throw new ArgumentException("ToAddress is not a valid email address", nameof(config.ToAddress));
+        }
+
+        if (string.IsNullOrWhiteSpace(config.Host))
+        {
+            throw new ArgumentException("Host cannot be empty", nameof(config.Host));
+        }
+
+        if (config.Port is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(config.Port), "Port must be between 1 and 65535");
+        }
+
+        if (string.IsNullOrWhiteSpace(config.SMTPUser))
+        {
+            throw new ArgumentException("SMTPUser cannot be empty", nameof(config.SMTPUser));
+        }
+
+        if (string.IsNullOrWhiteSpace(config.SMTPPassword))
+        {
+            throw new ArgumentException("SMTPPassword cannot be empty", nameof(config.SMTPPassword));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate email notification configuration before running the step and parse sender/recipient addresses safely
- connect to SMTP servers with automatic TLS negotiation instead of forcing plaintext connections
- correct the default SMTP host value used by the email notification config

## Testing
- dotnet build SeudoCI.Pipeline.Modules.EmailNotify/SeudoCI.Pipeline.Modules.EmailNotify.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fc0861d3dc832e8f978beac1b1a229