### PR TITLE
Fix FTP and SFTP distribute steps

### DIFF
--- a/SeudoCI.Pipeilne.Modules.FTPDistribute/FTPDistributeStep.cs
+++ b/SeudoCI.Pipeilne.Modules.FTPDistribute/FTPDistributeStep.cs
@@ -3,7 +3,7 @@
 namespace SeudoCI.Pipeline.Modules.FTPDistribute;
 
 using FluentFTP;
-using Core;
+using SeudoCI.Core;
 
 public class FTPDistributeStep : IDistributeStep<FTPDistributeConfig>
 {
@@ -28,8 +28,9 @@ public class FTPDistributeStep : IDistributeStep<FTPDistributeConfig>
             // Upload all archived files using modern async FTP client
             var uploadTask = UploadFilesAsync(archiveResults, workspace, results);
             uploadTask.GetAwaiter().GetResult();
-            
-            return new DistributeStepResults { IsSuccess = true };
+
+            results.IsSuccess = true;
+            return results;
         }
         catch (Exception e)
         {

--- a/SeudoCI.Pipeline.Modules.SFTPDistribute/SFTPDistributeStep.cs
+++ b/SeudoCI.Pipeline.Modules.SFTPDistribute/SFTPDistributeStep.cs
@@ -8,8 +8,8 @@ using SeudoCI.Core;
 
 public class SFTPDistributeStep : IDistributeStep<SFTPDistributeConfig>
 {
-    private SFTPDistributeConfig _config;
-    private ILogger _logger;
+    private SFTPDistributeConfig _config = null!;
+    private ILogger _logger = null!;
 
     public string? Type => "SFTP Upload";
 
@@ -34,6 +34,7 @@ public class SFTPDistributeStep : IDistributeStep<SFTPDistributeConfig>
                 {
                     Upload(archiveInfo, workspace);
                     stepResult.Success = true;
+                    stepResult.Message = "Upload completed successfully";
                     results.FileResults.Add(stepResult);
                 }
                 catch (Exception e)
@@ -41,10 +42,12 @@ public class SFTPDistributeStep : IDistributeStep<SFTPDistributeConfig>
                     stepResult.Success = false;
                     stepResult.Message = e.Message;
                     results.FileResults.Add(stepResult);
-                    throw new Exception("File upload failed");
+                    throw new Exception($"File upload failed for {archiveInfo.ArchiveFileName}", e);
                 }
             }
-            return new DistributeStepResults { IsSuccess = true };
+
+            results.IsSuccess = true;
+            return results;
         }
         // One or more archived files failed to upload
         catch (Exception e)
@@ -58,36 +61,51 @@ public class SFTPDistributeStep : IDistributeStep<SFTPDistributeConfig>
     public void Upload(ArchiveStepResults archiveInfo, ITargetWorkspace workspace)
     {
         // Supply the password via fake keyboard input
+        var passwordAuthMethod = new PasswordAuthenticationMethod(_config.Username, _config.Password);
         var keyboardAuthMethod = new KeyboardInteractiveAuthenticationMethod(_config.Username);
-        keyboardAuthMethod.AuthenticationPrompt += (sender, args) => {
-            foreach (AuthenticationPrompt prompt in args.Prompts)
+        keyboardAuthMethod.AuthenticationPrompt += (_, args) =>
+        {
+            foreach (var prompt in args.Prompts)
             {
-                if (prompt.Request.IndexOf("Password:", StringComparison.InvariantCultureIgnoreCase) != -1)
+                if (prompt.Request.IndexOf("Password", StringComparison.InvariantCultureIgnoreCase) != -1)
                 {
                     prompt.Response = _config.Password;
                 }
             }
         };
-                                                                                           
-        var connectionInfo = new ConnectionInfo(_config.Host, _config.Port, _config.Username, keyboardAuthMethod);
 
-        using (var client = new SftpClient(connectionInfo))
+        var connectionInfo = new ConnectionInfo(_config.Host, _config.Port, _config.Username, passwordAuthMethod, keyboardAuthMethod);
+
+        using var client = new SftpClient(connectionInfo);
+
+        try
         {
             _logger.Write($"Uploading {archiveInfo.ArchiveFileName} to {_config.Host} {_config.WorkingDirectory}", LogType.SmallBullet);
 
             client.Connect();
-            client.ChangeDirectory(_config.WorkingDirectory);
 
-            string filename = archiveInfo.ArchiveFileName;
-            string filepath = $"{workspace.GetDirectory(TargetDirectory.Archives)}/{filename}";
+            if (!string.IsNullOrWhiteSpace(_config.WorkingDirectory))
+            {
+                client.ChangeDirectory(_config.WorkingDirectory);
+            }
 
-            using (var stream = new FileStream(filepath, FileMode.Open))
+            var archivesDirectory = workspace.GetDirectory(TargetDirectory.Archives);
+            var localFilePath = Path.Combine(archivesDirectory, archiveInfo.ArchiveFileName);
+
+            using (var stream = workspace.FileSystem.OpenRead(localFilePath))
             {
                 client.BufferSize = 4 * 1024;
-                client.UploadFile(stream, filename);
+                client.UploadFile(stream, archiveInfo.ArchiveFileName);
             }
 
             _logger.Write("Upload succeeded", LogType.SmallBullet);
+        }
+        finally
+        {
+            if (client.IsConnected)
+            {
+                client.Disconnect();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the FTP distribute step uses the correct SeudoCI.Core abstractions and returns collected file results
- harden the SFTP distribute step by initialising dependencies, reporting per-file results, and using robust authentication/file access

## Testing
- dotnet build SeudoCI.Pipeilne.Modules.FTPDistribute/SeudoCI.Pipeilne.Modules.FTPDistribute.csproj
- dotnet build SeudoCI.Pipeline.Modules.SFTPDistribute/SeudoCI.Pipeline.Modules.SFTPDistribute.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fc0c3fddf0832e83c2143346448228