### PR TITLE
Complete pipeline step tests

### DIFF
--- a/SeudoCI.Pipeline.Modules.GitSource/GitSourceStep.cs
+++ b/SeudoCI.Pipeline.Modules.GitSource/GitSourceStep.cs
@@ -2,6 +2,7 @@
 
 namespace SeudoCI.Pipeline.Modules.GitSource;
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security;
 using System.Text;
@@ -1093,7 +1094,9 @@ public class GitSourceStep : ISourceStep<GitSourceConfig>
     
     private void GitReset(string workingDirectory, bool hard = true)
     {
-        var resetArgs = hard ? ["reset", "--hard", "HEAD"] : ["reset", "HEAD"];
+        List<string> resetArgs = hard
+            ? new List<string> { "reset", "--hard", "HEAD" }
+            : new List<string> { "reset", "HEAD" };
         ExecuteGitCommandWithArgs(resetArgs, workingDirectory);
         ExecuteGitCommandWithArgs(["clean", "-fd"], workingDirectory);
     }

--- a/SeudoCI.Pipeline.Tests/ModuleMetadataTests.cs
+++ b/SeudoCI.Pipeline.Tests/ModuleMetadataTests.cs
@@ -1,0 +1,196 @@
+namespace SeudoCI.Pipeline.Tests;
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using SeudoCI.Pipeline.Modules.EmailNotify;
+using SeudoCI.Pipeline.Modules.FolderArchive;
+using SeudoCI.Pipeline.Modules.FTPDistribute;
+using SeudoCI.Pipeline.Modules.GitSource;
+using SeudoCI.Pipeline.Modules.PerforceSource;
+using SeudoCI.Pipeline.Modules.PerforceSource.Shared;
+using SeudoCI.Pipeline.Modules.SFTPDistribute;
+using SeudoCI.Pipeline.Modules.SMBDistribute;
+using SeudoCI.Pipeline.Modules.SteamDistribute;
+using SeudoCI.Pipeline.Modules.ShellBuild;
+using SeudoCI.Pipeline.Modules.UnityBuild;
+using SeudoCI.Pipeline.Modules.ZipArchive;
+using SeudoCI.Pipeline.Shared;
+
+/// <summary>
+/// Validates module metadata and registry integration for every pipeline module.
+/// </summary>
+[TestFixture]
+public class ModuleMetadataTests
+{
+    private static readonly ModuleExpectation[] Expectations =
+    [
+        ModuleExpectation.Create<GitSourceModule, ISourceModule, GitSourceStep, GitSourceConfig>("Git", "Git"),
+        ModuleExpectation.Create<PerforceModule, ISourceModule, PerforceStep, PerforceConfig>("Perforce", "Perforce"),
+        ModuleExpectation.Create<ShellBuildModule, IBuildModule, ShellBuildStep, ShellBuildStepConfig>("Shell", "Shell Build"),
+        ModuleExpectation.Create<UnityStandardBuildModule, IBuildModule, UnityStandardBuildStep, UnityStandardBuildConfig>("Unity (Standard)", "Unity Standard Build"),
+        ModuleExpectation.Create<UnityParameterizedBuildModule, IBuildModule, UnityParameterizedBuildStep, UnityParameterizedBuildConfig>("Unity (Parameterized)", "Unity Parameterized Build"),
+        ModuleExpectation.Create<UnityExecuteMethodBuildModule, IBuildModule, UnityExecuteMethodBuildStep, UnityExecuteMethodBuildConfig>("Unity (Execute Method)", "Unity Execute Method"),
+        ModuleExpectation.Create<FolderArchiveModule, IArchiveModule, FolderArchiveStep, FolderArchiveConfig>("Folder", "Folder"),
+        ModuleExpectation.Create<ZipArchiveModule, IArchiveModule, ZipArchiveStep, ZipArchiveConfig>("Zip", "Zip File"),
+        ModuleExpectation.Create<FTPDistributeModule, IDistributeModule, FTPDistributeStep, FTPDistributeConfig>("FTP", "FTP Upload"),
+        ModuleExpectation.Create<SFTPDistributeModule, IDistributeModule, SFTPDistributeStep, SFTPDistributeConfig>("SFTP", "SFTP Upload"),
+        ModuleExpectation.Create<SMBDistributeModule, IDistributeModule, SMBDistributeStep, SMBDistributeConfig>("SMB", "SMB Transfer"),
+        ModuleExpectation.Create<SteamDistributeModule, IDistributeModule, SteamDistributeStep, SteamDistributeConfig>("Steam", "Steam Upload"),
+        ModuleExpectation.Create<EmailNotifyModule, INotifyModule, EmailNotifyStep, EmailNotifyConfig>("Email", "Email Notification")
+    ];
+
+    public static IEnumerable<TestCaseData> ModuleExpectationCases => Expectations
+        .Select(expectation => new TestCaseData(expectation)
+            .SetName($"{nameof(Module_ShouldExposeValidMetadata)}({expectation.ModuleType.Name})"));
+
+    [TestCaseSource(nameof(ModuleExpectationCases))]
+    public void Module_ShouldExposeValidMetadata(ModuleExpectation expectation)
+    {
+        var module = expectation.CreateModule();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(module, Is.Not.Null, "Module factory returned null.");
+            Assert.That(module, Is.InstanceOf(expectation.ModuleInterface));
+            Assert.That(module.GetType(), Is.EqualTo(expectation.ModuleType));
+            Assert.That(module.Name, Is.EqualTo(expectation.ExpectedName));
+            Assert.That(module.StepConfigName, Is.EqualTo(expectation.ExpectedStepConfigName));
+            Assert.That(module.StepType, Is.EqualTo(expectation.ExpectedStepType));
+            Assert.That(module.StepConfigType, Is.EqualTo(expectation.ExpectedStepConfigType));
+            Assert.That(module.StepType, Is.Not.Null);
+            Assert.That(module.StepConfigType, Is.Not.Null);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(module.StepType!.IsAbstract, Is.False, "Step type must be concrete.");
+            Assert.That(module.StepType.GetConstructor(Type.EmptyTypes), Is.Not.Null,
+                "Step type must provide a public parameterless constructor for reflection instantiation.");
+            Assert.That(module.StepConfigType!.IsAbstract, Is.False, "Config type must be concrete.");
+            Assert.That(module.StepConfigType.GetConstructor(Type.EmptyTypes), Is.Not.Null,
+                "Config type must provide a public parameterless constructor for JSON deserialization.");
+        });
+
+        var category = expectation.Category;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(category.StepInterfaceType.IsAssignableFrom(module.StepType!), Is.True,
+                $"{module.StepType} must implement {category.StepInterfaceType}.");
+            Assert.That(category.ConfigBaseType.IsAssignableFrom(module.StepConfigType!), Is.True,
+                $"{module.StepConfigType} must inherit from {category.ConfigBaseType}.");
+            Assert.That(typeof(IPipelineStep).IsAssignableFrom(module.StepType), Is.True,
+                "Step type must implement IPipelineStep.");
+            Assert.That(typeof(IInitializable<>).MakeGenericType(module.StepConfigType)
+                .IsAssignableFrom(module.StepType), Is.True,
+                "Step type must be initializable with the module's configuration type.");
+        });
+    }
+
+    [Test]
+    public void ModuleRegistry_ShouldReturnModulesAcrossCategories()
+    {
+        var registry = new ModuleRegistry();
+        var modules = Expectations.Select(expectation => new
+        {
+            Expectation = expectation,
+            Module = expectation.CreateModule()
+        }).ToList();
+
+        foreach (var entry in modules)
+        {
+            registry.RegisterModule(entry.Module);
+        }
+
+        Assert.That(registry.GetAllModules(), Is.EquivalentTo(modules.Select(m => m.Module)));
+
+        foreach (var entry in modules)
+        {
+            var expectation = entry.Expectation;
+            var module = entry.Module;
+
+            var getModules = typeof(ModuleRegistry)
+                .GetMethod(nameof(ModuleRegistry.GetModules))!
+                .MakeGenericMethod(expectation.ModuleInterface);
+            var modulesByInterface = ((IEnumerable)getModules.Invoke(registry, null)!)
+                .Cast<object>()
+                .ToList();
+
+            Assert.That(modulesByInterface, Does.Contain(module));
+
+            var getModulesForStep = typeof(ModuleRegistry)
+                .GetMethod(nameof(ModuleRegistry.GetModulesForStepType))!
+                .MakeGenericMethod(expectation.Category.StepInterfaceType);
+            var modulesByStep = ((IEnumerable)getModulesForStep.Invoke(registry, null)!)
+                .Cast<object>()
+                .ToList();
+
+            Assert.That(modulesByStep, Does.Contain(module));
+        }
+    }
+
+    [Test]
+    public void ModuleRegistry_ShouldRegisterConvertersForAllConfigs()
+    {
+        var registry = new ModuleRegistry();
+
+        foreach (var expectation in Expectations)
+        {
+            registry.RegisterModule(expectation.CreateModule());
+        }
+
+        var converters = registry.GetJsonConverters();
+
+        foreach (var expectation in Expectations)
+        {
+            var category = expectation.Category;
+            var converter = converters.FirstOrDefault(c => c.CanConvert(category.ConfigBaseType));
+
+            Assert.That(converter, Is.Not.Null,
+                $"Expected a JSON converter for base config type {category.ConfigBaseType.Name}.");
+
+            var serializer = new JsonSerializer();
+            serializer.Converters.Add(converter!);
+
+            using var reader = new JsonTextReader(new StringReader($"{{ \"Type\": \"{expectation.ExpectedStepConfigName}\" }}"));
+            var deserialized = serializer.Deserialize(reader, category.ConfigBaseType);
+
+            Assert.That(deserialized, Is.InstanceOf(expectation.ExpectedStepConfigType));
+        }
+    }
+
+    public sealed record ModuleExpectation(
+        Func<IModule> Factory,
+        Type ModuleType,
+        Type ModuleInterface,
+        Type ExpectedStepType,
+        Type ExpectedStepConfigType,
+        string ExpectedName,
+        string ExpectedStepConfigName)
+    {
+        public static ModuleExpectation Create<TModule, TInterface, TStep, TConfig>(string expectedName, string expectedStepConfigName)
+            where TModule : class, TInterface, IModule, new()
+            where TInterface : IModule
+            where TStep : class
+            where TConfig : StepConfig
+        {
+            return new ModuleExpectation(
+                Factory: static () => new TModule(),
+                ModuleType: typeof(TModule),
+                ModuleInterface: typeof(TInterface),
+                ExpectedStepType: typeof(TStep),
+                ExpectedStepConfigType: typeof(TConfig),
+                ExpectedName: expectedName,
+                ExpectedStepConfigName: expectedStepConfigName);
+        }
+
+        public IModule CreateModule() => Factory();
+
+        public ModuleCategoryAttribute Category => ModuleInterface.GetCustomAttribute<ModuleCategoryAttribute>()
+            ?? throw new InvalidOperationException($"Module interface {ModuleInterface.Name} is missing ModuleCategoryAttribute.");
+    }
+}

--- a/SeudoCI.Pipeline.Tests/ProjectPipelineTest.cs
+++ b/SeudoCI.Pipeline.Tests/ProjectPipelineTest.cs
@@ -1,5 +1,6 @@
 using NSubstitute;
 using SeudoCI.Core;
+using SeudoCI.Pipeline;
 
 namespace SeudoCI.Pipeline.Tests;
 
@@ -21,45 +22,175 @@ public class ProjectPipelineTest
     [Test]
     public void LoadBuildStepModules_LoadsAllModules()
     {
-        Assert.Fail();
+        var sourceConfig = new TestSourceStepConfig();
+        var buildConfig = new TestBuildStepConfig();
+        var archiveConfig = new TestArchiveStepConfig();
+        var distributeConfig = new TestDistributeStepConfig();
+        var notifyConfig = new TestNotifyStepConfig();
+
+        var targetConfig = new BuildTargetConfig
+        {
+            TargetName = "target",
+            SourceSteps = [sourceConfig],
+            BuildSteps = [buildConfig],
+            ArchiveSteps = [archiveConfig],
+            DistributeSteps = [distributeConfig],
+            NotifySteps = [notifyConfig],
+        };
+
+        var pipeline = CreatePipeline(targetConfig);
+
+        var sourceStep = Substitute.For<ISourceStep>();
+        var buildStep = Substitute.For<IBuildStep>();
+        var archiveStep = Substitute.For<IArchiveStep>();
+        var distributeStep = Substitute.For<IDistributeStep>();
+        var notifyStep = Substitute.For<INotifyStep>();
+
+        _loader.CreatePipelineStep<ISourceStep>(sourceConfig, _workspace, _logger).Returns(sourceStep);
+        _loader.CreatePipelineStep<IBuildStep>(buildConfig, _workspace, _logger).Returns(buildStep);
+        _loader.CreatePipelineStep<IArchiveStep>(archiveConfig, _workspace, _logger).Returns(archiveStep);
+        _loader.CreatePipelineStep<IDistributeStep>(distributeConfig, _workspace, _logger).Returns(distributeStep);
+        _loader.CreatePipelineStep<INotifyStep>(notifyConfig, _workspace, _logger).Returns(notifyStep);
+
+        pipeline.LoadBuildStepModules(_loader, _workspace, _logger);
+
+        CollectionAssert.AreEquivalent(new[] { sourceStep }, pipeline.GetPipelineSteps<ISourceStep>());
+        CollectionAssert.AreEquivalent(new[] { buildStep }, pipeline.GetPipelineSteps<IBuildStep>());
+        CollectionAssert.AreEquivalent(new[] { archiveStep }, pipeline.GetPipelineSteps<IArchiveStep>());
+        CollectionAssert.AreEquivalent(new[] { distributeStep }, pipeline.GetPipelineSteps<IDistributeStep>());
+        CollectionAssert.AreEquivalent(new[] { notifyStep }, pipeline.GetPipelineSteps<INotifyStep>());
+
+        _loader.Received(1).CreatePipelineStep<ISourceStep>(sourceConfig, _workspace, _logger);
+        _loader.Received(1).CreatePipelineStep<IBuildStep>(buildConfig, _workspace, _logger);
+        _loader.Received(1).CreatePipelineStep<IArchiveStep>(archiveConfig, _workspace, _logger);
+        _loader.Received(1).CreatePipelineStep<IDistributeStep>(distributeConfig, _workspace, _logger);
+        _loader.Received(1).CreatePipelineStep<INotifyStep>(notifyConfig, _workspace, _logger);
     }
-        
+
     [Test]
     public void CreatePipelineSteps_WithSourceStepType_ReturnsSourceSteps()
     {
-        var config = new ProjectConfig();
-        var pipeline = new ProjectPipeline(config, "target");
-            
+        var sourceConfig = new TestSourceStepConfig();
+        var pipeline = CreatePipeline(new BuildTargetConfig
+        {
+            TargetName = "target",
+            SourceSteps = [sourceConfig],
+        });
+
         var mockSourceStep = Substitute.For<ISourceStep>();
-            
-        _loader.CreatePipelineStep<ISourceStep>(Arg.Any<StepConfig>(), _workspace, _logger).Returns(mockSourceStep);
-            
+
+        _loader.CreatePipelineStep<ISourceStep>(sourceConfig, _workspace, _logger).Returns(mockSourceStep);
+
         var steps = pipeline.CreatePipelineSteps<ISourceStep>(_loader, _workspace, _logger);
-            
+
         CollectionAssert.Contains(steps, mockSourceStep);
     }
 
     [Test]
     public void CreatePipelineSteps_WithBuildStepType_ReturnsBuildSteps()
     {
-        Assert.Fail();
+        var buildConfig = new TestBuildStepConfig();
+        var pipeline = CreatePipeline(new BuildTargetConfig
+        {
+            TargetName = "target",
+            BuildSteps = [buildConfig],
+        });
+
+        var buildStep = Substitute.For<IBuildStep>();
+
+        _loader.CreatePipelineStep<IBuildStep>(buildConfig, _workspace, _logger).Returns(buildStep);
+
+        var steps = pipeline.CreatePipelineSteps<IBuildStep>(_loader, _workspace, _logger);
+
+        CollectionAssert.AreEquivalent(new[] { buildStep }, steps);
     }
-        
+
     [Test]
     public void CreatePipelineSteps_WithArchiveStepType_ReturnsBuildSteps()
     {
-        Assert.Fail();
+        var archiveConfig = new TestArchiveStepConfig();
+        var pipeline = CreatePipeline(new BuildTargetConfig
+        {
+            TargetName = "target",
+            ArchiveSteps = [archiveConfig],
+        });
+
+        var archiveStep = Substitute.For<IArchiveStep>();
+
+        _loader.CreatePipelineStep<IArchiveStep>(archiveConfig, _workspace, _logger).Returns(archiveStep);
+
+        var steps = pipeline.CreatePipelineSteps<IArchiveStep>(_loader, _workspace, _logger);
+
+        CollectionAssert.AreEquivalent(new[] { archiveStep }, steps);
     }
-        
+
     [Test]
     public void CreatePipelineSteps_WithDistributeStepType_ReturnsBuildSteps()
     {
-        Assert.Fail();
+        var distributeConfig = new TestDistributeStepConfig();
+        var pipeline = CreatePipeline(new BuildTargetConfig
+        {
+            TargetName = "target",
+            DistributeSteps = [distributeConfig],
+        });
+
+        var distributeStep = Substitute.For<IDistributeStep>();
+
+        _loader.CreatePipelineStep<IDistributeStep>(distributeConfig, _workspace, _logger).Returns(distributeStep);
+
+        var steps = pipeline.CreatePipelineSteps<IDistributeStep>(_loader, _workspace, _logger);
+
+        CollectionAssert.AreEquivalent(new[] { distributeStep }, steps);
     }
-        
+
     [Test]
     public void CreatePipelineSteps_WithNotifyStepType_ReturnsBuildSteps()
     {
-        Assert.Fail();
+        var notifyConfig = new TestNotifyStepConfig();
+        var pipeline = CreatePipeline(new BuildTargetConfig
+        {
+            TargetName = "target",
+            NotifySteps = [notifyConfig],
+        });
+
+        var notifyStep = Substitute.For<INotifyStep>();
+
+        _loader.CreatePipelineStep<INotifyStep>(notifyConfig, _workspace, _logger).Returns(notifyStep);
+
+        var steps = pipeline.CreatePipelineSteps<INotifyStep>(_loader, _workspace, _logger);
+
+        CollectionAssert.AreEquivalent(new[] { notifyStep }, steps);
+    }
+
+    private static ProjectPipeline CreatePipeline(BuildTargetConfig targetConfig)
+    {
+        var projectConfig = new ProjectConfig();
+        projectConfig.BuildTargets.Add(targetConfig);
+        return new ProjectPipeline(projectConfig, targetConfig.TargetName);
+    }
+
+    private sealed class TestSourceStepConfig : SourceStepConfig
+    {
+        public override string Name => nameof(TestSourceStepConfig);
+    }
+
+    private sealed class TestBuildStepConfig : BuildStepConfig
+    {
+        public override string Name => nameof(TestBuildStepConfig);
+    }
+
+    private sealed class TestArchiveStepConfig : ArchiveStepConfig
+    {
+        public override string Name => nameof(TestArchiveStepConfig);
+    }
+
+    private sealed class TestDistributeStepConfig : DistributeStepConfig
+    {
+        public override string Name => nameof(TestDistributeStepConfig);
+    }
+
+    private sealed class TestNotifyStepConfig : NotifyStepConfig
+    {
+        public override string Name => nameof(TestNotifyStepConfig);
     }
 }

--- a/SeudoCI.Pipeline.Tests/SeudoCI.Pipeline.Tests.csproj
+++ b/SeudoCI.Pipeline.Tests/SeudoCI.Pipeline.Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="JetBrains.Annotations" Version="2025.1.0-eap1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
@@ -25,7 +26,17 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\SeudoCI.Pipeilne.Modules.FTPDistribute\SeudoCI.Pipeilne.Modules.FTPDistribute.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.EmailNotify\SeudoCI.Pipeline.Modules.EmailNotify.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.FolderArchive\SeudoCI.Pipeline.Modules.FolderArchive.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.GitSource\SeudoCI.Pipeline.Modules.GitSource.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.PerforceSource\SeudoCI.Pipeline.Modules.PerforceSource.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.SFTPDistribute\SeudoCI.Pipeline.Modules.SFTPDistribute.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.SMBDistribute\SeudoCI.Pipeline.Modules.SMBDistribute.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.SteamDistribute\SeudoCI.Pipeline.Modules.SteamDistribute.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.ShellBuild\SeudoCI.Pipeline.Modules.ShellBuild.csproj" />
       <ProjectReference Include="..\SeudoCI.Pipeline.Modules.UnityBuild\SeudoCI.Pipeline.Modules.UnityBuild.csproj" />
+      <ProjectReference Include="..\SeudoCI.Pipeline.Modules.ZipArchive\SeudoCI.Pipeline.Modules.ZipArchive.csproj" />
       <ProjectReference Include="..\SeudoCI.Pipeline.Shared\SeudoCI.Pipeline.Shared.csproj" />
       <ProjectReference Include="..\SeudoCI.Pipeline\SeudoCI.Pipeline.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- add ModuleMetadataTests to validate each pipeline module's metadata, registry integration, and JSON config converter wiring
- update the pipeline test project to reference all module assemblies and Newtonsoft.Json for converter assertions
- fix GitSourceStep reset argument construction to use strongly-typed lists for the module tests to compile
- finish ProjectPipeline tests by covering module loading and step creation across all pipeline step categories

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test SeudoCI.Pipeline.Tests/SeudoCI.Pipeline.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fc11edb1c8832eaf9c58e28b35f73f