### PR TITLE
Implement cooperative cancellation for active builds

### DIFF
--- a/SeudoCI.Agent.Tests/BuildQueueTest.cs
+++ b/SeudoCI.Agent.Tests/BuildQueueTest.cs
@@ -1,5 +1,6 @@
 namespace SeudoCI.Agent.Tests;
 
+using System.Threading;
 using NSubstitute;
 using Core;
 using Pipeline;
@@ -189,8 +190,10 @@ public class BuildQueueTest
         projectConfig2.BuildTargets.Add(new BuildTargetConfig { TargetName = "Debug" });
         
         // Mock builder to return success for first build, then we can check second build starts
-        _mockBuilder.Build(Arg.Any<IPipelineRunner>(), projectConfig1, Arg.Any<string>()).Returns(true);
-        _mockBuilder.Build(Arg.Any<IPipelineRunner>(), projectConfig2, Arg.Any<string>()).Returns(true);
+        _mockBuilder.Build(Arg.Any<IPipelineRunner>(), projectConfig1, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _mockBuilder.Build(Arg.Any<IPipelineRunner>(), projectConfig2, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         // Act
         buildQueue.EnqueueBuild(projectConfig1);
@@ -204,6 +207,6 @@ public class BuildQueueTest
         Assert.That(allBuilds.Count(), Is.EqualTo(2));
         
         // Verify builder was called for both projects
-        _mockBuilder.Received().Build(Arg.Any<IPipelineRunner>(), projectConfig1, Arg.Any<string>());
+        _mockBuilder.Received().Build(Arg.Any<IPipelineRunner>(), projectConfig1, Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/SeudoCI.Agent.Tests/BuilderTest.cs
+++ b/SeudoCI.Agent.Tests/BuilderTest.cs
@@ -1,5 +1,6 @@
 namespace SeudoCI.Agent.Tests;
 
+using System.Threading;
 using NSubstitute;
 using Pipeline;
 using Core;
@@ -51,6 +52,6 @@ public class BuilderTest
 
         builder.Build(_mockPipeline, config, target);
             
-        _mockPipeline.Received().ExecutePipeline(config, target, _mockLoader);
+        _mockPipeline.Received().ExecutePipeline(config, target, _mockLoader, Arg.Any<CancellationToken>());
     }
 }

--- a/SeudoCI.Pipeline.Shared/IPipelineRunner.cs
+++ b/SeudoCI.Pipeline.Shared/IPipelineRunner.cs
@@ -1,6 +1,9 @@
-﻿namespace SeudoCI.Pipeline;
+﻿using System.Threading;
+
+namespace SeudoCI.Pipeline;
 
 public interface IPipelineRunner
 {
-    void ExecutePipeline(ProjectConfig projectConfig, string buildTargetName, IModuleLoader moduleLoader);
+    void ExecutePipeline(ProjectConfig projectConfig, string buildTargetName, IModuleLoader moduleLoader,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- propagate build cancellation requests through BuildQueue to cancel the running builder
- add cancellation-aware execution to Builder and PipelineRunner so build steps observe cancellation tokens
- update tests to cover the new cancellation-aware method signatures

## Testing
- `dotnet test` *(fails: Microsoft.Build.Exceptions.InternalLoggerException: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68fc73e30ff8832e93e283ddbaccc698