### PR TITLE
Expose running build state in queue API

### DIFF
--- a/SeudoCI.Agent.Shared/BuildResult.cs
+++ b/SeudoCI.Agent.Shared/BuildResult.cs
@@ -10,6 +10,7 @@ public class BuildResult
     public enum Status
     {
         Queued,
+        Running,
         Complete,
         Failed,
         Cancelled

--- a/SeudoCI.Agent.Tests/API/Controllers/QueueControllerTest.cs
+++ b/SeudoCI.Agent.Tests/API/Controllers/QueueControllerTest.cs
@@ -53,33 +53,40 @@ public class QueueControllerTest
         var projectConfig = new ProjectConfig { ProjectName = "TestProject" };
         var builds = new[]
         {
-            new BuildResult 
-            { 
-                Id = 1, 
-                ProjectConfiguration = projectConfig, 
+            new BuildResult
+            {
+                Id = 1,
+                ProjectConfiguration = projectConfig,
                 TargetName = "Debug",
-                BuildStatus = BuildResult.Status.Queued 
+                BuildStatus = BuildResult.Status.Queued
             },
-            new BuildResult 
-            { 
-                Id = 2, 
-                ProjectConfiguration = projectConfig, 
+            new BuildResult
+            {
+                Id = 2,
+                ProjectConfiguration = projectConfig,
                 TargetName = "Release",
-                BuildStatus = BuildResult.Status.Complete 
+                BuildStatus = BuildResult.Status.Complete
             },
-            new BuildResult 
-            { 
-                Id = 3, 
-                ProjectConfiguration = projectConfig, 
+            new BuildResult
+            {
+                Id = 3,
+                ProjectConfiguration = projectConfig,
                 TargetName = "Test",
-                BuildStatus = BuildResult.Status.Cancelled 
+                BuildStatus = BuildResult.Status.Cancelled
             },
-            new BuildResult 
-            { 
-                Id = 4, 
-                ProjectConfiguration = projectConfig, 
+            new BuildResult
+            {
+                Id = 4,
+                ProjectConfiguration = projectConfig,
                 TargetName = "Deploy",
-                BuildStatus = BuildResult.Status.Failed 
+                BuildStatus = BuildResult.Status.Failed
+            },
+            new BuildResult
+            {
+                Id = 5,
+                ProjectConfiguration = projectConfig,
+                TargetName = "Hotfix",
+                BuildStatus = BuildResult.Status.Running
             }
         };
         _mockBuildQueue.GetAllBuildResults().Returns(builds);
@@ -97,11 +104,11 @@ public class QueueControllerTest
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
         
-        Assert.That(root.GetProperty("TotalBuilds").GetInt32(), Is.EqualTo(4));
+        Assert.That(root.GetProperty("TotalBuilds").GetInt32(), Is.EqualTo(5));
         Assert.That(root.GetProperty("QueuedBuilds").GetInt32(), Is.EqualTo(1)); // Only the Queued status
-        Assert.That(root.GetProperty("RunningBuilds").GetInt32(), Is.EqualTo(0)); // No Running status in current enum
+        Assert.That(root.GetProperty("RunningBuilds").GetInt32(), Is.EqualTo(1));
         Assert.That(root.GetProperty("CompletedBuilds").GetInt32(), Is.EqualTo(2)); // Complete + Cancelled
-        Assert.That(root.GetProperty("Builds").GetArrayLength(), Is.EqualTo(4));
+        Assert.That(root.GetProperty("Builds").GetArrayLength(), Is.EqualTo(5));
         
         // Verify build results (access through the original response)
         var originalResponse = okResult.Value!;

--- a/SeudoCI.Agent/API/Controllers/QueueController.cs
+++ b/SeudoCI.Agent/API/Controllers/QueueController.cs
@@ -26,7 +26,7 @@ public class QueueController(IBuildQueue buildQueue) : ControllerBase
                 Builds = results,
                 TotalBuilds = results.Length,
                 QueuedBuilds = results.Count(r => r.BuildStatus == BuildResult.Status.Queued),
-                RunningBuilds = 0, // TODO: Add Running status to BuildResult.Status enum
+                RunningBuilds = results.Count(r => r.BuildStatus == BuildResult.Status.Running),
                 CompletedBuilds = results.Count(r => r.BuildStatus == BuildResult.Status.Complete || r.BuildStatus == BuildResult.Status.Cancelled)
             };
             return Ok(response);

--- a/SeudoCI.Agent/BuildQueue.cs
+++ b/SeudoCI.Agent/BuildQueue.cs
@@ -75,6 +75,8 @@ public class BuildQueue(Builder builder, IModuleLoader moduleLoader, ILogger log
                     logger.QueueNotification($"Building project '{build.ProjectConfiguration.ProjectName}', {printableTarget}");
 
                     ActiveBuild = build;
+                    ActiveBuild.BuildStatus = BuildResult.Status.Running;
+
                     var queueToken = _tokenSource?.Token ?? CancellationToken.None;
                     using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(queueToken);
                     _activeBuildCancellationSource = cancellationSource;


### PR DESCRIPTION
## Summary
- add a Running status to build results and report active builds through the queue endpoint
- update the queue processor to flag builds as running and mark them complete or failed when finished
- extend the queue controller tests to cover the running state count

## Testing
- dotnet test SeudoCI.sln *(fails: MSB4017 TerminalLogger error in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fc742d8578832eb469542c10d43bd3