### PR TITLE
Fix module loader nullability and YAML parsing for build targets

### DIFF
--- a/SeudoCI.Core.Tests/MockFileSystem.cs
+++ b/SeudoCI.Core.Tests/MockFileSystem.cs
@@ -34,7 +34,7 @@ public class MockFile
 
     public byte[] Data { get; private set; }
 
-    private MockMemoryStream _writeStream;
+    private MockMemoryStream? _writeStream;
 
     public MockFile()
     {
@@ -48,15 +48,18 @@ public class MockFile
 
     public Stream OpenRead()
     {
-        _writeStream.Flush();
-        Data = _writeStream.ToArray();
+        if (_writeStream is { CanWrite: true })
+        {
+            _writeStream.Flush();
+            Data = _writeStream.ToArray();
+        }
         var readStream = new MockMemoryStream(Data, OnFlush);
         return readStream;
     }
 
     public Stream OpenWrite()
     {
-        if (_writeStream.CanWrite)
+        if (_writeStream is { CanWrite: true })
         {
             throw new IOException("Can't write to mock file, the mock file stream is already open");
         }

--- a/SeudoCI.Core/TargetWorkspace.cs
+++ b/SeudoCI.Core/TargetWorkspace.cs
@@ -18,7 +18,7 @@ public class TargetWorkspace : ITargetWorkspace
 
     public IFileSystem FileSystem { get; }
     
-    public IProjectWorkspace ProjectWorkspace { get; set; }
+    public IProjectWorkspace ProjectWorkspace { get; set; } = null!;
         
     public TargetWorkspace(string baseDirectory, IFileSystem fileSystem, IMacros? parentMacros = null)
     {

--- a/SeudoCI.Pipeline.Shared/Config/ProjectConfig.cs
+++ b/SeudoCI.Pipeline.Shared/Config/ProjectConfig.cs
@@ -8,5 +8,5 @@ public class ProjectConfig
 {
     public string ProjectName { get; set; } = string.Empty;
         
-    public List<BuildTargetConfig> BuildTargets { get; } = [];
+    public List<BuildTargetConfig> BuildTargets { get; set; } = [];
 }

--- a/SeudoCI.Pipeline.Shared/Modules/IModuleLoader.cs
+++ b/SeudoCI.Pipeline.Shared/Modules/IModuleLoader.cs
@@ -9,5 +9,5 @@ using Core;
 public interface IModuleLoader
 {
     IModuleRegistry Registry { get; }
-    T CreatePipelineStep<T>(StepConfig config, ITargetWorkspace workspace, ILogger logger) where T : IPipelineStep;
+    T? CreatePipelineStep<T>(StepConfig config, ITargetWorkspace workspace, ILogger logger) where T : IPipelineStep;
 }


### PR DESCRIPTION
## Summary
- guard the mock file write stream to satisfy nullable analysis during tests
- initialize the target workspace project reference and allow project configs to populate build targets from YAML
- update the module loader API and implementation to return nullable pipeline steps with better error handling

## Testing
- dotnet test --logger "console;verbosity=minimal" --filter "FullyQualifiedName~BuildSpecificTarget_ExceptionDuringEnqueue_ReturnsBadRequest"

------
https://chatgpt.com/codex/tasks/task_e_68fc76c6dc1c832e907d6107dcfaa097