### PR TITLE
Add coverage for ProjectWorkspace and StringExtensions

### DIFF
--- a/SeudoCI.Core.Tests/ProjectWorkspaceTest.cs
+++ b/SeudoCI.Core.Tests/ProjectWorkspaceTest.cs
@@ -6,30 +6,59 @@ public class ProjectWorkspaceTest
     [Test]
     public void GetDirectory_ReturnsDirRelativeToBaseDir()
     {
-        Assert.Fail();
+        var fileSystem = new MockFileSystem();
+        var workspace = new ProjectWorkspace("/project", fileSystem);
+
+        Assert.That(workspace.GetDirectory(ProjectDirectory.Project), Is.EqualTo("/project"));
+        Assert.That(workspace.GetDirectory(ProjectDirectory.Targets), Is.EqualTo("/project/Targets"));
+        Assert.That(workspace.GetDirectory(ProjectDirectory.Logs), Is.EqualTo("/project/Logs"));
     }
-        
+
     [Test]
     public void CleanDirectory_DeletesDirectory()
     {
-        Assert.Fail();
+        var fileSystem = new MockFileSystem();
+        var workspace = new ProjectWorkspace("/project", fileSystem);
+        var targetsDirectory = workspace.GetDirectory(ProjectDirectory.Targets);
+
+        fileSystem.CreateDirectory(targetsDirectory);
+        Assume.That(fileSystem.DirectoryExists(targetsDirectory), Is.True);
+
+        workspace.CleanDirectory(ProjectDirectory.Targets);
+
+        Assert.That(fileSystem.DirectoryExists(targetsDirectory), Is.False);
     }
-        
+
     [Test]
     public void InitializeDirectories_CreatesProjectDirectory()
     {
-        Assert.Fail();
+        var fileSystem = new MockFileSystem();
+        var workspace = new ProjectWorkspace("/project", fileSystem);
+
+        workspace.InitializeDirectories();
+
+        Assert.That(fileSystem.DirectoryExists("/project"), Is.True);
     }
-        
+
     [Test]
     public void InitializeDirectories_CreatesTargetsDirectory()
     {
-        Assert.Fail();            
+        var fileSystem = new MockFileSystem();
+        var workspace = new ProjectWorkspace("/project", fileSystem);
+
+        workspace.InitializeDirectories();
+
+        Assert.That(fileSystem.DirectoryExists("/project/Targets"), Is.True);
     }
-        
+
     [Test]
     public void InitializeDirectories_CreatesLogsDirectory()
     {
-        Assert.Fail();
+        var fileSystem = new MockFileSystem();
+        var workspace = new ProjectWorkspace("/project", fileSystem);
+
+        workspace.InitializeDirectories();
+
+        Assert.That(fileSystem.DirectoryExists("/project/Logs"), Is.True);
     }
 }

--- a/SeudoCI.Core.Tests/StringExtensionsTest.cs
+++ b/SeudoCI.Core.Tests/StringExtensionsTest.cs
@@ -6,12 +6,20 @@ public class StringExtensionsTest
     [Test]
     public void SanitizeFilename_ReplacesSpaces()
     {
-        Assert.Fail();
+        var sanitized = "My Project Name".SanitizeFilename();
+
+        Assert.That(sanitized, Is.EqualTo("My_Project_Name"));
     }
-        
+
     [Test]
     public void SanitizeFilename_DoesNotContainInvalidCharacters()
     {
-        Assert.Fail();
+        var invalidName = "File<>:\"/\\|?*Name";
+        var sanitized = invalidName.SanitizeFilename();
+
+        foreach (var invalidChar in Path.GetInvalidFileNameChars())
+        {
+            Assert.That(sanitized.Contains(invalidChar), Is.False, $"Sanitized name should not contain '{invalidChar}'");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- flesh out the MockFileSystem so directory and file helpers behave predictably in tests
- add ProjectWorkspace unit tests covering directory creation and cleanup
- add StringExtensions tests to ensure filename sanitization replaces spaces and invalid characters

## Testing
- dotnet test SeudoCI.Core.Tests/SeudoCI.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fc78182e14832eb0c4a1192e04ba85