### PR TITLE
Fix ShellBuild step command quoting

### DIFF
--- a/SeudoCI.Pipeline.Modules.ShellBuild/ShellBuildStep.cs
+++ b/SeudoCI.Pipeline.Modules.ShellBuild/ShellBuildStep.cs
@@ -44,16 +44,17 @@ public class ShellBuildStep : IBuildStep<ShellBuildStepConfig>
             // Replace variables in string that begin and end with the % character
             var command = workspace.Macros.ReplaceVariablesInText(_config.Command);
 
-            var startInfo = new ProcessStartInfo
+            var startInfo = new ProcessStartInfo("bash")
             {
-                FileName = "bash",
-                Arguments = $"-c \"{command.Replace("\"", "\\\"")}\"",
                 WorkingDirectory = workspace.GetDirectory(TargetDirectory.Source),
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(command);
 
             using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
 


### PR DESCRIPTION
## Summary
- avoid manual quoting when invoking bash by using `ProcessStartInfo.ArgumentList`

## Testing
- dotnet build SeudoCI.sln

------
https://chatgpt.com/codex/tasks/task_e_68fc6ba3f1b4832eaedc1161ee6d9f12