### PR TITLE
Improve notification resilience and email templating

### DIFF
--- a/SeudoCI.Pipeline.Modules.EmailNotify.Shared/EmailNotifyConfig.cs
+++ b/SeudoCI.Pipeline.Modules.EmailNotify.Shared/EmailNotifyConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace SeudoCI.Pipeline.Modules.EmailNotify;
+﻿using System.Collections.Generic;
+
+namespace SeudoCI.Pipeline.Modules.EmailNotify;
 
 /// <inheritdoc />
 /// <summary>
@@ -6,11 +8,46 @@
 /// </summary>
 public class EmailNotifyConfig : NotifyStepConfig
 {
+    public EmailNotifyConfig()
+    {
+        RunOnFailure = true;
+    }
+
     public override string Name { get; } = "Email Notification";
+
     public string FromAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Legacy single recipient property retained for backwards compatibility.
+    /// When specified the address will be merged into <see cref="ToAddresses"/>.
+    /// </summary>
     public string ToAddress { get; set; } = string.Empty;
+
+    public List<string> ToAddresses { get; set; } = new();
+
+    public List<string> CcAddresses { get; set; } = new();
+
+    public List<string> BccAddresses { get; set; } = new();
+
     public string Host { get; set; } = "smtp.gmail.com";
+
     public int Port { get; set; } = 587;
+
     public string SMTPUser { get; set; } = string.Empty;
+
+    public string SMTPUserEnvironmentVariable { get; set; } = string.Empty;
+
     public string SMTPPassword { get; set; } = string.Empty;
+
+    public string SMTPPasswordEnvironmentVariable { get; set; } = string.Empty;
+
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    public int RetryBackoffSeconds { get; set; } = 5;
+
+    public bool FailPipelineOnError { get; set; } = true;
+
+    public string SubjectTemplate { get; set; } = string.Empty;
+
+    public string BodyTemplate { get; set; } = string.Empty;
 }

--- a/SeudoCI.Pipeline.Modules.EmailNotify/EmailNotifyStep.cs
+++ b/SeudoCI.Pipeline.Modules.EmailNotify/EmailNotifyStep.cs
@@ -1,16 +1,34 @@
-﻿using JetBrains.Annotations;
 
-namespace SeudoCI.Pipeline.Modules.EmailNotify;
-
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using JetBrains.Annotations;
 using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
-using Core;
+using SeudoCI.Core;
+
+namespace SeudoCI.Pipeline.Modules.EmailNotify;
 
 public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
 {
+    private const string DefaultSubjectTemplate = "Build {{PipelineStatus}} • %project_name% • %build_target_name%";
+
+    private const string DefaultBodyTemplate =
+        "Build {{PipelineStatus}} for %project_name% (%build_target_name%) at {{BuildTimestamp}}.\n\n" +
+        "Pipeline summary:\n{{SummaryTable}}\n\n" +
+        "Failed Stage: {{FailedStage}}\n" +
+        "Failure Reason: {{FailureReason}}";
+
     private EmailNotifyConfig _config = null!;
     private ILogger _logger = null!;
+    private IReadOnlyList<MailboxAddress> _toRecipients = Array.Empty<MailboxAddress>();
+    private IReadOnlyList<MailboxAddress> _ccRecipients = Array.Empty<MailboxAddress>();
+    private IReadOnlyList<MailboxAddress> _bccRecipients = Array.Empty<MailboxAddress>();
+    private string _smtpUser = string.Empty;
+    private string _smtpPassword = string.Empty;
 
     public string? Type => "Email Notification";
 
@@ -20,49 +38,157 @@ public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
+        _logger = logger;
+
+        NormalizeConfiguration(config);
         ValidateConfiguration(config);
 
         _config = config;
-        _logger = logger;
+
+        _toRecipients = ParseAddresses(MergeAddresses(config.ToAddresses, config.ToAddress), nameof(config.ToAddresses));
+        _ccRecipients = ParseAddresses(config.CcAddresses, nameof(config.CcAddresses));
+        _bccRecipients = ParseAddresses(config.BccAddresses, nameof(config.BccAddresses));
+
+        _smtpUser = ResolveSecret(config.SMTPUser, config.SMTPUserEnvironmentVariable, nameof(config.SMTPUser));
+        _smtpPassword = ResolveSecret(config.SMTPPassword, config.SMTPPasswordEnvironmentVariable, nameof(config.SMTPPassword));
     }
 
-    public NotifyStepResults ExecuteStep(DistributeSequenceResults distributeResults, ITargetWorkspace workspace)
+    public NotifyStepResults ExecuteStep(PipelineRunResults pipelineResults, ITargetWorkspace workspace)
     {
         try
         {
-            string subject = "Build Completed • %project_name% • %build_target_name%";
-            subject = workspace.Macros.ReplaceVariablesInText(subject);
-            SendMessage(_config.FromAddress, _config.ToAddress, subject, $"Build completed in {distributeResults.Duration} seconds.");
-            return new NotifyStepResults { IsSuccess = true };
+            var tokens = BuildTemplateTokens(pipelineResults);
+            var subject = RenderTemplate(_config.SubjectTemplate, DefaultSubjectTemplate, tokens, workspace);
+            var body = RenderTemplate(_config.BodyTemplate, DefaultBodyTemplate, tokens, workspace);
+
+            var message = BuildMessage(subject, body);
+
+            if (TrySendWithRetries(message, out var sendException))
+            {
+                return new NotifyStepResults { IsSuccess = true };
+            }
+
+            if (_config.FailPipelineOnError)
+            {
+                return new NotifyStepResults { IsSuccess = false, Exception = sendException };
+            }
+
+            _logger.Write(
+                $"Email notification delivery failed but FailPipelineOnError is disabled: {sendException?.Message}",
+                LogType.Alert);
+
+            return new NotifyStepResults { IsSuccess = true, Exception = sendException };
         }
         catch (Exception e)
         {
-            return new NotifyStepResults { IsSuccess = false, Exception = e };
+            if (_config.FailPipelineOnError)
+            {
+                return new NotifyStepResults { IsSuccess = false, Exception = e };
+            }
+
+            _logger.Write($"Email notification failed but pipeline configured to continue: {e.Message}", LogType.Alert);
+            return new NotifyStepResults { IsSuccess = true, Exception = e };
         }
     }
 
-    private void SendMessage(string fromAddress, string toAddress, string subject, string body)
+    private static void NormalizeConfiguration(EmailNotifyConfig config)
+    {
+        config.ToAddresses ??= new List<string>();
+        config.CcAddresses ??= new List<string>();
+        config.BccAddresses ??= new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(config.ToAddress) &&
+            !config.ToAddresses.Any(address => string.Equals(address, config.ToAddress, StringComparison.OrdinalIgnoreCase)))
+        {
+            config.ToAddresses.Add(config.ToAddress);
+        }
+
+        config.ToAddress = string.Empty;
+    }
+
+    private static string RenderTemplate(string? userTemplate, string defaultTemplate,
+        IReadOnlyDictionary<string, string> tokens, ITargetWorkspace workspace)
+    {
+        var template = string.IsNullOrWhiteSpace(userTemplate) ? defaultTemplate : userTemplate;
+        foreach (var token in tokens)
+        {
+            template = template.Replace($"{{{{{token.Key}}}}}", token.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return workspace.Macros.ReplaceVariablesInText(template);
+    }
+
+    private MimeMessage BuildMessage(string subject, string body)
     {
         var message = new MimeMessage();
-        message.From.Add(MailboxAddress.Parse(fromAddress));
-        message.To.Add(MailboxAddress.Parse(toAddress));
+        message.From.Add(MailboxAddress.Parse(_config.FromAddress));
+        foreach (var address in _toRecipients)
+        {
+            message.To.Add(address);
+        }
+        foreach (var address in _ccRecipients)
+        {
+            message.Cc.Add(address);
+        }
+        foreach (var address in _bccRecipients)
+        {
+            message.Bcc.Add(address);
+        }
+
         message.Subject = subject;
         message.Body = new TextPart("plain")
         {
             Text = body
         };
 
-        _logger.Write($"Sending email notification to {toAddress}", LogType.SmallBullet);
+        return message;
+    }
 
-        using (var client = new SmtpClient())
+    private bool TrySendWithRetries(MimeMessage message, out Exception? sendException)
+    {
+        sendException = null;
+        var attempts = Math.Max(1, _config.MaxRetryAttempts);
+        var backoff = TimeSpan.FromSeconds(Math.Max(0, _config.RetryBackoffSeconds));
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
         {
-            client.Timeout = 10000;
-            client.Connect(_config.Host, _config.Port, GetSecureSocketOptions(_config.Port));
-            client.AuthenticationMechanisms.Remove("XOAUTH2");
-            client.Authenticate(_config.SMTPUser, _config.SMTPPassword);
-            client.Send(message);
-            client.Disconnect(true);
+            try
+            {
+                SendMessage(message);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                sendException = ex;
+                _logger.Write($"Attempt {attempt} to send email notification failed: {ex.Message}", LogType.Alert);
+
+                if (attempt < attempts && backoff > TimeSpan.Zero)
+                {
+                    _logger.Write($"Retrying email delivery in {backoff.TotalSeconds} seconds...", LogType.SmallBullet);
+                    Thread.Sleep(backoff);
+                }
+            }
         }
+
+        return false;
+    }
+
+    private void SendMessage(MimeMessage message)
+    {
+        _logger.Write($"Sending email notification to {string.Join(", ", _toRecipients.Select(r => r.Address))}", LogType.SmallBullet);
+
+        using var client = new SmtpClient();
+        client.Timeout = 10000;
+        client.Connect(_config.Host, _config.Port, GetSecureSocketOptions(_config.Port));
+        client.AuthenticationMechanisms.Remove("XOAUTH2");
+
+        if (!string.IsNullOrWhiteSpace(_smtpUser))
+        {
+            client.Authenticate(_smtpUser, _smtpPassword);
+        }
+
+        client.Send(message);
+        client.Disconnect(true);
 
         _logger.Write("Email notification sent", LogType.SmallBullet);
     }
@@ -78,40 +204,199 @@ public class EmailNotifyStep : INotifyStep<EmailNotifyConfig>
         {
             throw new ArgumentException("FromAddress cannot be empty", nameof(config.FromAddress));
         }
-
         if (!MailboxAddress.TryParse(config.FromAddress, out _))
         {
             throw new ArgumentException("FromAddress is not a valid email address", nameof(config.FromAddress));
         }
 
-        if (string.IsNullOrWhiteSpace(config.ToAddress))
+        var toRecipients = MergeAddresses(config.ToAddresses ?? new List<string>(), string.Empty).ToList();
+        if (toRecipients.Count == 0)
         {
-            throw new ArgumentException("ToAddress cannot be empty", nameof(config.ToAddress));
+            throw new ArgumentException("At least one recipient must be specified", nameof(config.ToAddresses));
+        }
+        foreach (var address in toRecipients)
+        {
+            if (!MailboxAddress.TryParse(address, out _))
+            {
+                throw new ArgumentException($"Recipient '{address}' is not a valid email address", nameof(config.ToAddresses));
+            }
         }
 
-        if (!MailboxAddress.TryParse(config.ToAddress, out _))
-        {
-            throw new ArgumentException("ToAddress is not a valid email address", nameof(config.ToAddress));
-        }
+        ValidateAddresses(config.CcAddresses ?? new List<string>(), nameof(config.CcAddresses));
+        ValidateAddresses(config.BccAddresses ?? new List<string>(), nameof(config.BccAddresses));
 
         if (string.IsNullOrWhiteSpace(config.Host))
         {
             throw new ArgumentException("Host cannot be empty", nameof(config.Host));
         }
-
         if (config.Port is < 1 or > 65535)
         {
             throw new ArgumentOutOfRangeException(nameof(config.Port), "Port must be between 1 and 65535");
         }
-
-        if (string.IsNullOrWhiteSpace(config.SMTPUser))
+        if (config.MaxRetryAttempts < 1)
         {
-            throw new ArgumentException("SMTPUser cannot be empty", nameof(config.SMTPUser));
+            throw new ArgumentOutOfRangeException(nameof(config.MaxRetryAttempts), "MaxRetryAttempts must be at least 1");
+        }
+        if (config.RetryBackoffSeconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(config.RetryBackoffSeconds), "RetryBackoffSeconds cannot be negative");
+        }
+        if (string.IsNullOrWhiteSpace(config.SMTPUser) && string.IsNullOrWhiteSpace(config.SMTPUserEnvironmentVariable))
+        {
+            throw new ArgumentException("SMTPUser or SMTPUserEnvironmentVariable must be provided", nameof(config.SMTPUser));
+        }
+        if (string.IsNullOrWhiteSpace(config.SMTPPassword) && string.IsNullOrWhiteSpace(config.SMTPPasswordEnvironmentVariable))
+        {
+            throw new ArgumentException("SMTPPassword or SMTPPasswordEnvironmentVariable must be provided", nameof(config.SMTPPassword));
+        }
+    }
+
+    private static void ValidateAddresses(IEnumerable<string> addresses, string propertyName)
+    {
+        foreach (var address in addresses)
+        {
+            var trimmed = address?.Trim();
+            if (string.IsNullOrEmpty(trimmed) || !MailboxAddress.TryParse(trimmed, out _))
+            {
+                throw new ArgumentException($"Address '{address}' is not a valid email address", propertyName);
+            }
+        }
+    }
+
+    private static IEnumerable<string> MergeAddresses(IEnumerable<string> addresses, string legacyAddress)
+    {
+        var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(legacyAddress))
+        {
+            unique.Add(legacyAddress.Trim());
         }
 
-        if (string.IsNullOrWhiteSpace(config.SMTPPassword))
+        foreach (var address in addresses)
         {
-            throw new ArgumentException("SMTPPassword cannot be empty", nameof(config.SMTPPassword));
+            if (!string.IsNullOrWhiteSpace(address))
+            {
+                unique.Add(address.Trim());
+            }
         }
+
+        return unique;
+    }
+
+    private static IReadOnlyList<MailboxAddress> ParseAddresses(IEnumerable<string> addresses, string propertyName)
+    {
+        var parsed = new List<MailboxAddress>();
+        foreach (var address in addresses)
+        {
+            var trimmed = address?.Trim();
+            if (!string.IsNullOrEmpty(trimmed) && MailboxAddress.TryParse(trimmed, out var mailbox))
+            {
+                parsed.Add(mailbox);
+            }
+            else
+            {
+                throw new ArgumentException($"Address '{address}' is not a valid email address", propertyName);
+            }
+        }
+
+        return parsed;
+    }
+
+    private static string ResolveSecret(string explicitValue, string environmentVariable, string propertyName)
+    {
+        if (!string.IsNullOrWhiteSpace(environmentVariable))
+        {
+            var environmentValue = Environment.GetEnvironmentVariable(environmentVariable);
+            if (string.IsNullOrEmpty(environmentValue))
+            {
+                throw new InvalidOperationException($"Environment variable '{environmentVariable}' specified for {propertyName} is not set.");
+            }
+
+            return environmentValue;
+        }
+
+        return explicitValue;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildTemplateTokens(PipelineRunResults pipelineResults)
+    {
+        var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PipelineStatus"] = pipelineResults.IsPipelineSuccessful ? "Succeeded" : "Failed",
+            ["BuildTimestamp"] = DateTime.UtcNow.ToString("u"),
+            ["SummaryTable"] = BuildSummary(pipelineResults),
+            ["TotalDuration"] = FormatDuration(pipelineResults.SourceResults.Duration +
+                                                pipelineResults.BuildResults.Duration +
+                                                pipelineResults.ArchiveResults.Duration +
+                                                pipelineResults.DistributeResults.Duration)
+        };
+
+        var failure = FindFailure(pipelineResults);
+        tokens["FailedStage"] = failure.Stage;
+        tokens["FailureReason"] = failure.Reason;
+
+        foreach (var (name, results) in pipelineResults.EnumerateStages())
+        {
+            tokens[$"{name}Status"] = DescribeStatus(results);
+            tokens[$"{name}Duration"] = FormatDuration(results.Duration);
+            tokens[$"{name}Exception"] = results.Exception?.Message ?? string.Empty;
+        }
+
+        return tokens;
+    }
+
+    private static string BuildSummary(PipelineRunResults pipelineResults)
+    {
+        var builder = new StringBuilder();
+        foreach (var (name, results) in pipelineResults.EnumerateStages())
+        {
+            builder.Append(name.PadRight(11));
+            builder.Append(": ");
+            builder.Append(DescribeStatus(results));
+            builder.Append(' ');
+            builder.Append('(');
+            builder.Append(FormatDuration(results.Duration));
+            builder.Append(')');
+            builder.AppendLine();
+
+            if (!results.IsSuccess && results.Exception != null)
+            {
+                builder.AppendLine($"  Error: {results.Exception.Message}");
+            }
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string DescribeStatus(PipelineSequenceResults results)
+    {
+        if (results.IsSkipped)
+        {
+            return "Skipped";
+        }
+
+        return results.IsSuccess ? "Succeeded" : "Failed";
+    }
+
+    private static (string Stage, string Reason) FindFailure(PipelineRunResults pipelineResults)
+    {
+        foreach (var (name, results) in pipelineResults.EnumerateStages())
+        {
+            if (!results.IsSuccess)
+            {
+                return (name, results.Exception?.Message ?? "Unknown failure");
+            }
+        }
+
+        return ("None", "N/A");
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration == TimeSpan.Zero)
+        {
+            return "00:00:00";
+        }
+
+        return duration.ToString(@"hh\:mm\:ss");
     }
 }

--- a/SeudoCI.Pipeline.Shared/Config/NotifyStepConfig.cs
+++ b/SeudoCI.Pipeline.Shared/Config/NotifyStepConfig.cs
@@ -6,4 +6,10 @@
 /// </summary>
 public abstract class NotifyStepConfig : StepConfig
 {
+    /// <summary>
+    /// When true the notify sequence will execute even if the previous pipeline
+    /// sequence failed. This allows notification steps to report failures from
+    /// earlier stages instead of being skipped.
+    /// </summary>
+    public bool RunOnFailure { get; set; }
 }

--- a/SeudoCI.Pipeline.Shared/Results/PipelineRunResults.cs
+++ b/SeudoCI.Pipeline.Shared/Results/PipelineRunResults.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace SeudoCI.Pipeline;
+
+/// <summary>
+/// Aggregated results for an entire pipeline run. The object derives from
+/// <see cref="PipelineSequenceResults{T}"/> so it can be provided to notify
+/// steps while still exposing the individual sequence results that preceded the
+/// notification phase.
+/// </summary>
+public class PipelineRunResults : PipelineSequenceResults<DistributeStepResults>
+{
+    public PipelineRunResults(
+        SourceSequenceResults sourceResults,
+        BuildSequenceResults buildResults,
+        ArchiveSequenceResults archiveResults,
+        DistributeSequenceResults distributeResults)
+    {
+        SourceResults = sourceResults ?? throw new ArgumentNullException(nameof(sourceResults));
+        BuildResults = buildResults ?? throw new ArgumentNullException(nameof(buildResults));
+        ArchiveResults = archiveResults ?? throw new ArgumentNullException(nameof(archiveResults));
+        DistributeResults = distributeResults ?? throw new ArgumentNullException(nameof(distributeResults));
+
+        // Mirror the distribute results so existing logic that inspects the
+        // "previous" sequence continues to work transparently.
+        IsSuccess = distributeResults.IsSuccess;
+        IsSkipped = distributeResults.IsSkipped;
+        IsMandatory = distributeResults.IsMandatory;
+        Exception = distributeResults.Exception;
+        Duration = distributeResults.Duration;
+
+        StepResults.AddRange(distributeResults.StepResults);
+    }
+
+    public SourceSequenceResults SourceResults { get; }
+
+    public BuildSequenceResults BuildResults { get; }
+
+    public ArchiveSequenceResults ArchiveResults { get; }
+
+    public DistributeSequenceResults DistributeResults { get; }
+
+    /// <summary>
+    /// Calculates whether every pipeline stage prior to notification succeeded.
+    /// </summary>
+    public bool IsPipelineSuccessful => SourceResults.IsSuccess && BuildResults.IsSuccess &&
+                                        ArchiveResults.IsSuccess && DistributeResults.IsSuccess;
+
+    /// <summary>
+    /// Returns an ordered enumeration of all pipeline stages leading up to the
+    /// notification stage.
+    /// </summary>
+    public IReadOnlyList<(string Name, PipelineSequenceResults Results)> EnumerateStages() =>
+    [
+        ("Source", SourceResults),
+        ("Build", BuildResults),
+        ("Archive", ArchiveResults),
+        ("Distribute", DistributeResults)
+    ];
+}

--- a/SeudoCI.Pipeline.Shared/Steps/INotifyStep.cs
+++ b/SeudoCI.Pipeline.Shared/Steps/INotifyStep.cs
@@ -6,11 +6,11 @@ using SeudoCI.Pipeline.Shared;
 /// Pipeline step that publishes a notification after the pipeline has completed all of its other steps.
 /// </summary>
 [StepConfigMapping("NotifySteps")]
-public interface INotifyStep : IPipelineStep<DistributeSequenceResults, DistributeStepResults, NotifySequenceResults, NotifyStepResults>
+public interface INotifyStep : IPipelineStep<PipelineRunResults, DistributeStepResults, NotifySequenceResults, NotifyStepResults>
 {
 }
 
-public interface INotifyStep<T> : INotifyStep, IPipelineStepWithConfig<DistributeSequenceResults, DistributeStepResults, NotifySequenceResults, NotifyStepResults, T>
+public interface INotifyStep<T> : INotifyStep, IPipelineStepWithConfig<PipelineRunResults, DistributeStepResults, NotifySequenceResults, NotifyStepResults, T>
     where T : NotifyStepConfig
 {
 }

--- a/SeudoCI.Pipeline.Tests/PipelineRunnerTest.cs
+++ b/SeudoCI.Pipeline.Tests/PipelineRunnerTest.cs
@@ -1,7 +1,178 @@
+
+using System;
+using System.IO;
+using NSubstitute;
+using NUnit.Framework;
+using SeudoCI.Core;
+using SeudoCI.Pipeline;
+
 namespace SeudoCI.Pipeline.Tests;
 
 [TestFixture]
 public class PipelineRunnerTest
 {
-        
+    private ILogger _logger = null!;
+    private IModuleLoader _moduleLoader = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = Substitute.For<ILogger>();
+        _moduleLoader = Substitute.For<IModuleLoader>();
+    }
+
+    [Test]
+    public void ExecutePipeline_RunsNotifyAfterFailure_WhenConfigured()
+    {
+        using var tempDirectory = new TempDirectory();
+
+        var pipelineConfig = new PipelineConfig { BaseDirectory = tempDirectory.Path };
+        var runner = new PipelineRunner(pipelineConfig, _logger);
+
+        var projectConfig = CreateProjectConfig(runNotifyOnFailure: true);
+
+        var sourceStep = Substitute.For<ISourceStep>();
+        sourceStep.ExecuteStep(Arg.Any<ITargetWorkspace>()).Returns(new SourceStepResults { IsSuccess = true });
+        var buildStep = Substitute.For<IBuildStep>();
+        buildStep.ExecuteStep(Arg.Any<SourceSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new BuildStepResults { IsSuccess = false, Exception = new Exception("Build failed") });
+        var archiveStep = Substitute.For<IArchiveStep>();
+        archiveStep.ExecuteStep(Arg.Any<BuildSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new ArchiveStepResults { IsSuccess = true });
+        var distributeStep = Substitute.For<IDistributeStep>();
+        distributeStep.ExecuteStep(Arg.Any<ArchiveSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new DistributeStepResults { IsSuccess = true });
+        var notifyStep = Substitute.For<INotifyStep>();
+        notifyStep.ExecuteStep(Arg.Any<PipelineRunResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new NotifyStepResults { IsSuccess = true });
+
+        ConfigureModuleLoader(projectConfig, sourceStep, buildStep, archiveStep, distributeStep, notifyStep);
+
+        runner.ExecutePipeline(projectConfig, projectConfig.BuildTargets[0].TargetName, _moduleLoader);
+
+        notifyStep.Received(1).ExecuteStep(Arg.Is<PipelineRunResults>(results => !results.BuildResults.IsSuccess),
+            Arg.Any<ITargetWorkspace>());
+    }
+
+    [Test]
+    public void ExecutePipeline_SkipsNotifyAfterFailure_WhenNotConfigured()
+    {
+        using var tempDirectory = new TempDirectory();
+
+        var pipelineConfig = new PipelineConfig { BaseDirectory = tempDirectory.Path };
+        var runner = new PipelineRunner(pipelineConfig, _logger);
+
+        var projectConfig = CreateProjectConfig(runNotifyOnFailure: false);
+
+        var sourceStep = Substitute.For<ISourceStep>();
+        sourceStep.ExecuteStep(Arg.Any<ITargetWorkspace>()).Returns(new SourceStepResults { IsSuccess = true });
+        var buildStep = Substitute.For<IBuildStep>();
+        buildStep.ExecuteStep(Arg.Any<SourceSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new BuildStepResults { IsSuccess = false, Exception = new Exception("Build failed") });
+        var archiveStep = Substitute.For<IArchiveStep>();
+        archiveStep.ExecuteStep(Arg.Any<BuildSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new ArchiveStepResults { IsSuccess = true });
+        var distributeStep = Substitute.For<IDistributeStep>();
+        distributeStep.ExecuteStep(Arg.Any<ArchiveSequenceResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new DistributeStepResults { IsSuccess = true });
+        var notifyStep = Substitute.For<INotifyStep>();
+        notifyStep.ExecuteStep(Arg.Any<PipelineRunResults>(), Arg.Any<ITargetWorkspace>())
+            .Returns(new NotifyStepResults { IsSuccess = true });
+
+        ConfigureModuleLoader(projectConfig, sourceStep, buildStep, archiveStep, distributeStep, notifyStep);
+
+        runner.ExecutePipeline(projectConfig, projectConfig.BuildTargets[0].TargetName, _moduleLoader);
+
+        notifyStep.DidNotReceive().ExecuteStep(Arg.Any<PipelineRunResults>(), Arg.Any<ITargetWorkspace>());
+    }
+
+    private void ConfigureModuleLoader(ProjectConfig projectConfig,
+        ISourceStep sourceStep,
+        IBuildStep buildStep,
+        IArchiveStep archiveStep,
+        IDistributeStep distributeStep,
+        INotifyStep notifyStep)
+    {
+        var target = projectConfig.BuildTargets[0];
+        _moduleLoader.CreatePipelineStep<ISourceStep>(target.SourceSteps[0], Arg.Any<ITargetWorkspace>(), Arg.Any<ILogger>())
+            .Returns(sourceStep);
+        _moduleLoader.CreatePipelineStep<IBuildStep>(target.BuildSteps[0], Arg.Any<ITargetWorkspace>(), Arg.Any<ILogger>())
+            .Returns(buildStep);
+        _moduleLoader.CreatePipelineStep<IArchiveStep>(target.ArchiveSteps[0], Arg.Any<ITargetWorkspace>(), Arg.Any<ILogger>())
+            .Returns(archiveStep);
+        _moduleLoader.CreatePipelineStep<IDistributeStep>(target.DistributeSteps[0], Arg.Any<ITargetWorkspace>(), Arg.Any<ILogger>())
+            .Returns(distributeStep);
+        _moduleLoader.CreatePipelineStep<INotifyStep>(target.NotifySteps[0], Arg.Any<ITargetWorkspace>(), Arg.Any<ILogger>())
+            .Returns(notifyStep);
+    }
+
+    private static ProjectConfig CreateProjectConfig(bool runNotifyOnFailure)
+    {
+        var target = new BuildTargetConfig
+        {
+            TargetName = "default",
+            SourceSteps = [new TestSourceStepConfig()],
+            BuildSteps = [new TestBuildStepConfig()],
+            ArchiveSteps = [new TestArchiveStepConfig()],
+            DistributeSteps = [new TestDistributeStepConfig()],
+            NotifySteps = [new TestNotifyStepConfig { RunOnFailure = runNotifyOnFailure }]
+        };
+
+        return new ProjectConfig
+        {
+            ProjectName = "TestProject",
+            BuildTargets = { target }
+        };
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup failures in tests
+            }
+        }
+    }
+
+    private sealed class TestSourceStepConfig : SourceStepConfig
+    {
+        public override string Name => nameof(TestSourceStepConfig);
+    }
+
+    private sealed class TestBuildStepConfig : BuildStepConfig
+    {
+        public override string Name => nameof(TestBuildStepConfig);
+    }
+
+    private sealed class TestArchiveStepConfig : ArchiveStepConfig
+    {
+        public override string Name => nameof(TestArchiveStepConfig);
+    }
+
+    private sealed class TestDistributeStepConfig : DistributeStepConfig
+    {
+        public override string Name => nameof(TestDistributeStepConfig);
+    }
+
+    private sealed class TestNotifyStepConfig : NotifyStepConfig
+    {
+        public override string Name => nameof(TestNotifyStepConfig);
+    }
 }

--- a/SeudoCI.Pipeline/PipelineRunner.cs
+++ b/SeudoCI.Pipeline/PipelineRunner.cs
@@ -83,8 +83,11 @@ public class PipelineRunner(PipelineConfig config, ILogger logger) : IPipelineRu
             cancellationToken);
         var distributeResults = ExecuteSequence("Distribute", pipeline.GetPipelineSteps<IDistributeStep>(), archiveResults,
             targetWorkspace, cancellationToken);
-        var notifyResults = ExecuteSequence("Notify", pipeline.GetPipelineSteps<INotifyStep>(), distributeResults, targetWorkspace,
-            cancellationToken);
+
+        var pipelineRunResults = new PipelineRunResults(sourceResults, buildResults, archiveResults, distributeResults);
+        bool shouldRunNotifyOnFailure = pipeline.TargetConfig.NotifySteps.Any(step => step.RunOnFailure);
+        var notifyResults = ExecuteSequence("Notify", pipeline.GetPipelineSteps<INotifyStep>(), pipelineRunResults, targetWorkspace,
+            cancellationToken, shouldRunNotifyOnFailure);
 
         // Determine overall pipeline success
         bool overallSuccess = sourceResults.IsSuccess && buildResults.IsSuccess && archiveResults.IsSuccess && distributeResults.IsSuccess && notifyResults.IsSuccess;
@@ -154,7 +157,7 @@ public class PipelineRunner(PipelineConfig config, ILogger logger) : IPipelineRu
     // Pipeline execution step that had a step before it
     private TOutSeq ExecuteSequence<TInSeq, TOutSeq, TOutStep>(string? sequenceName,
         IReadOnlyCollection<IPipelineStep<TInSeq, TOutSeq, TOutStep>> sequenceSteps, TInSeq previousSequence,
-        ITargetWorkspace workspace, CancellationToken cancellationToken)
+        ITargetWorkspace workspace, CancellationToken cancellationToken, bool allowExecutionOnPreviousFailure = false)
         where TInSeq : PipelineSequenceResults // previous sequence results
         where TOutSeq : PipelineSequenceResults<TOutStep>, new() // current sequence results
         where TOutStep : PipelineStepResults, new() // current step results
@@ -171,25 +174,35 @@ public class PipelineRunner(PipelineConfig config, ILogger logger) : IPipelineRu
         // Verify that the pipeline has not previously failed
         if (!previousSequence.IsSuccess)
         {
-            logger.Write("Skipping, previous pipeline step failed", LogType.Failure);
-            logger.IndentLevel--;
-            results = new TOutSeq
+            if (!allowExecutionOnPreviousFailure)
             {
-                IsSuccess = false,
-                Exception = new Exception($"Skipped {sequenceName} sequence, previous sequence failed.")
-            };
-            return results;
+                logger.Write("Skipping, previous pipeline step failed", LogType.Failure);
+                logger.IndentLevel--;
+                results = new TOutSeq
+                {
+                    IsSuccess = false,
+                    Exception = new Exception($"Skipped {sequenceName} sequence, previous sequence failed.")
+                };
+                return results;
+            }
+
+            logger.Write("Previous pipeline sequence failed, continuing execution due to configuration", LogType.Alert);
         }
 
         if (previousSequence.IsSkipped)
         {
-            logger.Write($"Skipping {sequenceName} sequence, previous sequence was skipped.", LogType.Alert);
-            logger.IndentLevel--;
-            return new TOutSeq
+            if (!allowExecutionOnPreviousFailure)
             {
-                IsSuccess = true,
-                IsSkipped = true
-            };
+                logger.Write($"Skipping {sequenceName} sequence, previous sequence was skipped.", LogType.Alert);
+                logger.IndentLevel--;
+                return new TOutSeq
+                {
+                    IsSuccess = true,
+                    IsSkipped = true
+                };
+            }
+
+            logger.Write($"Previous sequence was skipped, continuing {sequenceName} due to configuration", LogType.Alert);
         }
 
         // Run the sequence


### PR DESCRIPTION
## Summary
- allow notification steps to opt into running after failed stages and provide them a PipelineRunResults context with the full sequence history
- expand the email notifier configuration with templated subject/body, multiple recipient lists, secret resolution, and retry/backoff controls
- enrich the email notification content with pipeline summaries and add unit coverage proving notify steps still run when configured for failure handling

## Testing
- MSBUILDTERMINALLOGGER=off dotnet test --nologo *(fails: existing SeudoCI.Core.Tests assertions fail in the current tree)*
- dotnet build SeudoCI.Pipeline.Modules.EmailNotify/SeudoCI.Pipeline.Modules.EmailNotify.csproj --nologo

------
https://chatgpt.com/codex/tasks/task_e_68fc78be2730832e97d53b2ce3276f0c